### PR TITLE
sentence correction

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -70,7 +70,7 @@ New forms of governance must acknowledge the networked commons connecting humani
 
 ===1.2 Legacy.===
 
-We can consider elections implemented by states, provinces and city municipalities as democracies where we are reduced to being passive recipients of a monologue. Citizens are called between substantially long periods of time, during elections, to provide a basic input: essentially accept or reject players in the same system: this is the bandwidth of the legacy system that is our so-called ''modern democracies''. Under these systems less than one percent of the population is able to vote on legislation or execute budgets while the rest are legally forced to outsource their full citizenship rights to a representing minority that eventually figures out how to perpetuate itself.
+We can consider elections implemented by states, provinces and city municipalities as democracies where we are reduced to being passive recipients of a monologue. Citizens are called between substantially long periods of time, during elections, to provide a basic input: essentially accept or reject players in the same system. This is the bandwidth of the legacy system that is our so-called ''modern democracies''. Under these systems less than one percent of the population is able to vote on legislation or execute budgets while the rest are legally forced to outsource their full citizenship rights to a representing minority that eventually figures out how to perpetuate itself.
 
 The technology behind ''representative democracies'' can be grouped in two sets:
 


### PR DESCRIPTION
two ":" in the same sentence. 

Before: Citizens are called between substantially long periods of time, during elections, to provide a basic input: essentially accept or reject players in the same system: this is the bandwidth of the legacy system that is our so-called ''modern democracies''. 

After: Citizens are called between substantially long periods of time, during elections, to provide a basic input: essentially accept or reject players in the same system. This is the bandwidth of the legacy system that is our so-called ''modern democracies''. 