### PR TITLE
Staying loyal to either-or structure

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -305,7 +305,7 @@ But unlike web based applications, Sovereign does not allow testimonial interact
 
 * '''Upvote''': Send a single ''VOTE'' delegation from the user to the commenter.
 
-* '''Downvote''': If a user disagrees with someone's comment, a ''downvote'' can either retrieve a ''VOTE'' from the commenter back to the user if there was a previous delegation. If no delegation relation exists among them, then a ''downvote'' will act as a penalty sending a ''VOTE'' from the commenter back to the funds of the organization implementing the Sovereign instance. The criteria for this kind of penalty can be set in the ''constitutional smart contract'' of the implementing organization.
+* '''Downvote''': If a user disagrees with someone's comment, a ''downvote'' can either retrieve a ''VOTE'' from the commenter back to the user if there was a previous delegation. Or if no delegation relation exists among them, then a ''downvote'' will act as a penalty sending a ''VOTE'' from the commenter back to the funds of the organization implementing the Sovereign instance. The criteria for this kind of penalty can be set in the ''constitutional smart contract'' of the implementing organization.
 
 This will make delegations more frequent across the platform. Debates constantly exposed to the risk of ''VOTE'' transactions means that they are subject to real political impact. This mechanism can help reward good arguments and punish the influence of trolling without requiring the need to develop moderating authorities in the system.
 


### PR DESCRIPTION
Sort of nitpicking here with this part: 

> If a user disagrees with someone's comment, a ''downvote'' can either retrieve a ''VOTE'' from the commenter back to the user if there was a previous delegation. If no delegation relation exists among them, then a ''downvote'' will act as a penalty sending a ''VOTE'' from the commenter back to the funds of the organization implementing the Sovereign instance. 

I think it's more readable if we keep the 'either-or' structure. Thought about doing something like "can either a) retrieve... ; or b) if no delegation...", but wasn't sold on that. 

So I just added an 'or' (if though it's between two sentences 🤔). Suggestion in this PR below: 

> If a user disagrees with someone's comment, a ''downvote'' can either retrieve a ''VOTE'' from the commenter back to the user if there was a previous delegation. Or if no delegation relation exists among them, then a ''downvote'' will act as a penalty sending a ''VOTE'' from the commenter back to the funds of the organization implementing the Sovereign instance. 