### PR TITLE
add Webster/Sainte-Laguë to counting methods

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -433,6 +433,7 @@ Finally, counting methods for the final or ongoing result of a decision within a
 * <code>Plurality</code>: Simple majority wins decision.
 * <code>Majority</code> A minimum percentage is required for winning decision.
 * [https://en.wikipedia.org/wiki/D%27Hondt_method <code>DHont</code>]: Widely used by Nation-State elections based on member lists.
+* [https://en.wikipedia.org/wiki/Webster/Sainte-Lagu%C3%AB_method <code>Webster/Sainte-Laguë</code>]: Widely used alternative to DHont based on member lists.
 * [https://en.wikipedia.org/wiki/Schulze_method <code>Schulze</code>]: Commonly used by open source communities and Pirate Parties using ranked choice ballots.
 * [http://ilpubs.stanford.edu:8090/422/1/1999-66.pdf <code>PageRank</code>]: Counts votes weighting voter reputation in a graph.
 


### PR DESCRIPTION
[Webster/Sainte-Laguë method](https://en.wikipedia.org/wiki/Webster/Sainte-Lagu%C3%AB_method) is an alternative to the D'Hondt method. D'Hondt favors larger parties compared to the Webster/Sainte-Laguë method. Used in Bosnia and Herzegovina, Iraq, Kosovo, Latvia, New Zealand, Norway and Sweden. In Germany it is used on the federal level for the Bundestag, and on the state level for the legislatures of Baden-Württemberg, Bremen, Hamburg, North Rhine-Westphalia, Rhineland-Palatinate, and Schleswig-Holstein.