### PR TITLE
numbering typo fixed (Acknowledgements is 6)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -121,7 +121,7 @@ Approaches aiming to prevent a Sybil Attack must ensure that it is possible for 
 
 <div id="Acknowledgements"></div>
 
-==4. Acknowledgements.==
+==6. Acknowledgements.==
 
 These are some of the minds that have contributed to this paper by reviewing it.
 


### PR DESCRIPTION
Fixed numbering typo. "4. Acknowledgements" to "6. Acknowledgements".